### PR TITLE
fix: patch read_datasets_from_db

### DIFF
--- a/ckanext/stadtzh_losdharvest/harvester.py
+++ b/ckanext/stadtzh_losdharvest/harvester.py
@@ -180,3 +180,18 @@ class StadtzhLosdHarvester(DCATRDFHarvester):
             return dataset_dict["name"]
 
         return None
+
+    def _read_datasets_from_db(self, guid):
+        """
+        Overwritten from DCATHarvester as the guid disappears from package_extras
+        when the dataset is updated outside the harvesting context.
+        """
+        datasets = super()._read_datasets_from_db(guid)
+        if not datasets:
+            datasets = (
+                model.Session.query(model.Package.id)
+                .filter(model.Package.name == guid)
+                .filter(model.Package.state == "active")
+                .all()
+            )
+        return datasets

--- a/ckanext/stadtzh_losdharvest/harvester.py
+++ b/ckanext/stadtzh_losdharvest/harvester.py
@@ -188,6 +188,10 @@ class StadtzhLosdHarvester(DCATRDFHarvester):
         """
         datasets = super()._read_datasets_from_db(guid)
         if not datasets:
+            log.info(
+                "Checking for datasets with id=guid, as the given guid was not"
+                " found in package_extras but we might have a package with that id."
+            )
             datasets = (
                 model.Session.query(model.Package.id)
                 .filter(model.Package.name == guid)


### PR DESCRIPTION
When a dataset is harvested (imported or changed) via the LOSD-Harvester it works as expected. As soon as a dataset is changed outside the harvesting context (e.g. CKAN GUI) the guid disappears from the package_extras. This way we have a fallback, in case the default check for an existing dataset fails.